### PR TITLE
Fix non-editable install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools ~= 0.1
+    stactools @ git+https://github.com/stac-utils/stactools@main
+    jinja2 ~= 3.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ packages = find_namespace:
 install_requires =
     stactools @ git+https://github.com/stac-utils/stactools@main
     jinja2 ~= 3.0
+include_package_data = True
 
 [options.packages.find]
 where = src

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,12 @@
+from stactools.testing import CliTestCase
+
+from stactools.browse.commands import browse_command
+
+
+class CommandsTest(CliTestCase):
+    def create_subcommand_functions(self):
+        return [browse_command]
+
+    def test_help(self):
+        result = self.run_command(["browse", "--help"])
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
This pins the stactools dependency to main. Once stactools settles on v0.2, this should be pinned.