### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     defaults:
       run:
         shell: bash -l {0}

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools @ git+https://github.com/stac-utils/stactools@main
-    jinja2 ~= 3.0
+    stactools >= 0.2.6
+    jinja2 >= 3.0
 include_package_data = True
 
 [options.packages.find]

--- a/src/stactools/browse/Dockerfile-node
+++ b/src/stactools/browse/Dockerfile-node
@@ -6,8 +6,8 @@ WORKDIR /opt/src
 RUN npm install --global http-server
 
 RUN git clone --depth=1 \
-    https://github.com/lossyrob/stac-browser.git \
-    --branch feature/ts
+    https://github.com/radiantearth/stac-browser \
+    --branch v2.0.0
 
 WORKDIR /opt/src/stac-browser
 

--- a/src/stactools/browse/commands.py
+++ b/src/stactools/browse/commands.py
@@ -29,16 +29,17 @@ def launch_browser(catalog_uri):
         rendered_docker_compose = template.render(
             catalog_dir=catalog_dir, catalog_filename=catalog_filename)
 
-        with open(os.path.join(tmp_dir, "docker-compose.yml"), 'w') as f:
+        compose_file = os.path.join(tmp_dir, "docker-compose.yml")
+        with open(compose_file, 'w') as f:
             f.write(rendered_docker_compose)
 
         curdir = os.path.abspath(os.curdir)
         try:
             os.chdir(tmp_dir)
-            p = Popen(['docker-compose', 'up'])
+            p = Popen(['docker-compose', '-f', compose_file, 'up'])
             p.wait()
         finally:
-            call(['docker-compose', 'kill'])
+            call(['docker-compose', '-f', compose_file, 'kill'])
             p.terminate()
             os.chdir(curdir)
 

--- a/src/stactools/browse/commands.py
+++ b/src/stactools/browse/commands.py
@@ -44,6 +44,7 @@ def launch_browser(catalog_uri):
 
 
 def browse_command(cli):
+
     @cli.command(
         'browse',
         short_help=('Launch a local stac-browser and tiler via docker '

--- a/src/stactools/browse/docker-compose.yml.template
+++ b/src/stactools/browse/docker-compose.yml.template
@@ -38,7 +38,7 @@ services:
       context: .
       dockerfile: Dockerfile-node
     ports:
-      - "1234:1234"
+      - "8080:8080"
     environment:
       - CATALOG_URL=http://localhost:4326/{{ catalog_filename }}
       - TILE_SOURCE_TEMPLATE=http://localhost:8000/cog/tiles/{z}/{x}/{y}?url={ASSET_HREF}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,6 +4,7 @@ from stactools.browse.commands import browse_command
 
 
 class CommandsTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [browse_command]
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,5 +4,6 @@ import stactools.browse
 
 
 class TestModule(unittest.TestCase):
+
     def test_version(self):
         self.assertIsNotNone(stactools.browse.__version__)


### PR DESCRIPTION
1. Set stactools and jinja2 dependencies better
2. Install versioned stac-browser
3. Fix port
4. Explicitly specify the compose file location to avoid a `COMPOSE_FILE` envvar from breaking the command

I'd like to do a new version release after this merge, so `pip install stactools-browse` will not break existing environments by installing a really old stactools.