### PR TITLE
Release v0.1.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# Configuration file for pre-commit (https://pre-commit.com/).
+# Please run `pre-commit run --all-files` when adding or changing entries.
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args: [--ignore-words=.codespellignore]
+        types_or: [jupyter, markdown, python, shell]
+  - repo: https://github.com/PyCQA/doc8
+    rev: 0.11.1
+    hooks:
+      - id: doc8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.942
+    hooks:
+      - id: mypy
+        args:
+          - --explicit-package-bases
+        additional_dependencies:
+          - click != 8.1.0
+          - jinja2
+          - stactools
+          - pystac
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.7] - 2022-04-14
+
+### Added
+
+- This changelog ([#7](https://github.com/stactools-packages/browse/pull/7))
+
+### Changed
+
+- Install versioned stac-browser ([#5](https://github.com/stactools-packages/browse/pull/5))
+- Use black (instead of yapf) for formatting ([#7](https://github.com/stactools-packages/browse/pull/7))
+- Use pytest ([#7](https://github.com/stactools-packages/browse/pull/7))
+
+### Fixed
+
+- Explicitly set the compose file location ([#5](https://github.com/stactools-packages/browse/pull/5))
+
+## Pre-0.1.7
+
+There was no CHANGELOG kept before version v0.1.7.
+
+[Unreleased]: <https://github.com/stactools-packages/browse/compare/v0.1.7..main>
+[0.1.7]: <https://github.com/stactools-packages/browse/compare/v0.1.6..v0.1.7>

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+mypy_path = src
+explicit_package_bases = True
+namespace_packages = True
+show_error_codes = True
+strict = True
+warn_unused_ignores = False
+
+[mypy-fsspec.*]
+ignore_missing_imports = True
+
+[mypy-osgeo.*]
+ignore_missing_imports = True
+
+[mypy-rasterio.*]
+ignore_missing_imports = True
+
+[mypy-s3fs.*]
+ignore_missing_imports = True
+
+[mypy-shapely.*]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black
 codespell
-coverage
 flake8
 pylint
+pytest
+pytest-cov
 pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,6 @@
+black
 codespell
 coverage
 flake8
 pylint
-sphinx
-sphinx-autobuild
-sphinx-click
-sphinxcontrib-fulltoc
-sphinxcontrib-napoleon
-yapf
+pre-commit

--- a/scripts/format
+++ b/scripts/format
@@ -20,6 +20,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Code formatting
-        yapf -ipr ${DIRS_TO_CHECK[@]}
+        pre-commit run black --all-files
+        pre-commit run isort --all-files
     fi
 fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -13,16 +13,12 @@ Execute project linters.
 "
 }
 
-DIRS_TO_CHECK=("src" "tests")
-
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Code formatting
-        yapf -dpr ${DIRS_TO_CHECK[@]}
         # Lint
-        flake8 ${DIRS_TO_CHECK[@]}
-
+        pre-commit run flake8 --all-files
+        pre-commit run mypy --all-files
     fi
 fi

--- a/scripts/publish
+++ b/scripts/publish
@@ -9,7 +9,7 @@ fi
 function usage() {
     echo -n \
         "Usage: $(basename "$0")
-Publish all stactools.browses.
+Publish stactools.browse.
 
 Options:
 --test    Publish to test pypi
@@ -49,6 +49,7 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     rm -rf dist
-    python setup.py sdist bdist_wheel
+    pip install build twine
+    python -m build --sdist --wheel
     twine upload ${TEST_PYPI} dist/*
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -27,7 +27,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docs/*.rst docs/**/*.rst \
             docs/*.ipynb docs/**/*.ipynb
 
-        coverage run --source=${COVERAGE_DIRS} -m unittest discover tests/
+        pytest --cov=stactools tests
         coverage xml
     fi
 fi

--- a/src/stactools/browse/__init__.py
+++ b/src/stactools/browse/__init__.py
@@ -1,4 +1,7 @@
-def register_plugin(registry):
+from stactools.cli.registry import Registry
+
+
+def register_plugin(registry: Registry) -> None:
     # Register subcommands
 
     from stactools.browse import commands
@@ -6,4 +9,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.browse_command)
 
 
-__version__ = '0.1.6'
+__version__ = "0.1.6"

--- a/src/stactools/browse/__init__.py
+++ b/src/stactools/browse/__init__.py
@@ -9,4 +9,4 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.browse_command)
 
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/src/stactools/browse/commands.py
+++ b/src/stactools/browse/commands.py
@@ -1,57 +1,58 @@
 import os
 import shutil
-from tempfile import TemporaryDirectory
 from subprocess import Popen, call
+from tempfile import TemporaryDirectory
 
 import click
 import jinja2
 from pystac.utils import make_absolute_href
 
 
-def launch_browser(catalog_uri):
+def launch_browser(catalog_uri: str) -> None:
     catalog_uri = make_absolute_href(catalog_uri)
 
     catalog_dir = os.path.dirname(catalog_uri)
     catalog_filename = os.path.basename(catalog_uri)
 
     with TemporaryDirectory() as tmp_dir:
-        for fname in ['Dockerfile-node', 'Dockerfile-titiler']:
+        for fname in ["Dockerfile-node", "Dockerfile-titiler"]:
             p = os.path.join(os.path.dirname(__file__), fname)
             shutil.copy(p, os.path.join(tmp_dir, fname))
 
         # Load template docker-compose
-        template_loader = jinja2.FileSystemLoader(
-            searchpath=os.path.dirname(__file__))
+        template_loader = jinja2.FileSystemLoader(searchpath=os.path.dirname(__file__))
         template_env = jinja2.Environment(loader=template_loader)
         template_file = "docker-compose.yml.template"
         template = template_env.get_template(template_file)
 
         rendered_docker_compose = template.render(
-            catalog_dir=catalog_dir, catalog_filename=catalog_filename)
+            catalog_dir=catalog_dir, catalog_filename=catalog_filename
+        )
 
         compose_file = os.path.join(tmp_dir, "docker-compose.yml")
-        with open(compose_file, 'w') as f:
+        with open(compose_file, "w") as f:
             f.write(rendered_docker_compose)
 
         curdir = os.path.abspath(os.curdir)
         try:
             os.chdir(tmp_dir)
-            p = Popen(['docker-compose', '-f', compose_file, 'up'])
-            p.wait()
+            process = Popen(["docker-compose", "-f", compose_file, "up"])
+            process.wait()
         finally:
-            call(['docker-compose', '-f', compose_file, 'kill'])
-            p.terminate()
+            call(["docker-compose", "-f", compose_file, "kill"])
+            process.terminate()
             os.chdir(curdir)
 
 
-def browse_command(cli):
-
+def browse_command(cli: click.Group) -> click.Command:
     @cli.command(
-        'browse',
-        short_help=('Launch a local stac-browser and tiler via docker '
-                    'to browse a STAC'))
-    @click.argument('catalog')
-    def cmd(catalog):
+        "browse",
+        short_help=(
+            "Launch a local stac-browser and tiler via docker " "to browse a STAC"
+        ),
+    )
+    @click.argument("catalog")
+    def cmd(catalog: str) -> None:
         """Launch docker containers that serve the STAC at CATALOG through stac-browser.
 
         This requires docker to be installed. This will build and run 3 containers,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,13 +1,15 @@
-from stactools.testing import CliTestCase
+from typing import Callable, List
+
+from click import Command, Group
+from stactools.testing.cli_test import CliTestCase
 
 from stactools.browse.commands import browse_command
 
 
 class CommandsTest(CliTestCase):
-
-    def create_subcommand_functions(self):
+    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
         return [browse_command]
 
-    def test_help(self):
-        result = self.run_command(["browse", "--help"])
+    def test_help(self) -> None:
+        result = self.run_command("browse --help")
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,6 +4,5 @@ import stactools.browse
 
 
 class TestModule(unittest.TestCase):
-
-    def test_version(self):
+    def test_version(self) -> None:
         self.assertIsNotNone(stactools.browse.__version__)


### PR DESCRIPTION
As mentioned in #5, we want to fix the latest version on PyPI so `pip install stactools-browse` works. This also includes upgrades to black, pre-commit, and pytest. No functional changes.